### PR TITLE
Zig 0.16.0 Migration

### DIFF
--- a/README.md
+++ b/README.md
@@ -288,7 +288,10 @@ pub fn main(init: std.process.Init) !void {
 zig build
 ./zig-out/bin/mcp-client ./zig-out/bin/mcp-zig                          # list tools
 ./zig-out/bin/mcp-client ./zig-out/bin/mcp-zig read_file '{"path":"."}'  # call a tool
+./zig-out/bin/mcp-client ./zig-out/bin/mcp-zig batch '{"operations":[{"tool":"read_file","arguments":{"path":"README.md","max_bytes":80}},{"tool":"list_dir","arguments":{"path":"src"}}]}'
 ```
+
+The `batch` tool returns a structured JSON object with ordered per-item results, so clients can group several filesystem reads into a single `tools/call` without losing partial-failure information.
 
 ---
 
@@ -297,9 +300,12 @@ zig build
 ```bash
 zig build                              # debug (fast compile)
 zig build -Doptimize=ReleaseSmall      # release (small binary)
+zig build -Dio-backend=evented         # Linux only; macOS/other targets fall back to threaded
 strip zig-out/bin/mcp-zig              # shrink further
 codesign --sign - --force zig-out/bin/mcp-zig   # macOS Apple Silicon only
 ```
+
+`mcp-zig` uses `std.Io.Threaded` by default. The `-Dio-backend=evented` option is gated to Linux builds so you can experiment with `std.Io.Evented` there without pulling in the current macOS `Dispatch` backend issues. On macOS and other non-Linux targets, the binaries continue to use `Threaded`.
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@
 
 [![License: MIT](https://img.shields.io/badge/License-MIT-blue.svg)](LICENSE)
 [![Build](https://github.com/justrach/mcp-zig/actions/workflows/build.yml/badge.svg)](https://github.com/justrach/mcp-zig/actions)
-[![Zig](https://img.shields.io/badge/Zig-0.15-f7a41d.svg)](https://ziglang.org)
+[![Zig](https://img.shields.io/badge/Zig-0.16-f7a41d.svg)](https://ziglang.org)
 [![MCP](https://img.shields.io/badge/MCP-2025--06--18-green.svg)](https://spec.modelcontextprotocol.io)
 
 **Build MCP servers that fit in a tweet-sized binary.**
@@ -87,7 +87,7 @@ Register with Claude Code in `~/.claude.json`:
 
 Restart Claude Code. Your tools appear as `mcp__my-server__read_file`, `mcp__my-server__list_dir`, etc.
 
-Requires [Zig 0.15](https://ziglang.org/download/).
+Requires [Zig 0.16.0](https://ziglang.org/download/).
 
 ---
 
@@ -115,9 +115,15 @@ exe.root_module.addImport("mcp", mcp_dep.module("mcp"));
 ```zig
 const mcp = @import("mcp");
 
-// Use the client
+// Use the client from a std.process.Init entry point
 const McpClient = mcp.client.McpClient;
-var client = try McpClient.init(alloc, &.{"/path/to/server"}, null);
+pub fn main(init: std.process.Init) !void {
+    const alloc = init.gpa;
+    const io = init.io;
+
+    var client = try McpClient.init(alloc, io, &.{"/path/to/server"}, null);
+    defer client.deinit();
+}
 
 // Use the registry
 const my_tools = mcp.registry.Registry(&.{
@@ -242,18 +248,23 @@ mcp-zig includes a client library for calling any MCP server programmatically �
 ```zig
 const McpClient = @import("client.zig").McpClient;
 
-var client = try McpClient.init(alloc, &.{"/path/to/server"}, null);
-defer client.deinit();
+pub fn main(init: std.process.Init) !void {
+    const alloc = init.gpa;
+    const io = init.io;
 
-const init_result = try client.initialize();
-defer alloc.free(init_result);
-try client.notifyInitialized();
+    var client = try McpClient.init(alloc, io, &.{"/path/to/server"}, null);
+    defer client.deinit();
 
-const tools = try client.listTools();
-defer alloc.free(tools);
+    const init_result = try client.initialize();
+    defer alloc.free(init_result);
+    try client.notifyInitialized();
 
-const result = try client.callTool("read_file", "{\"path\":\"hello.txt\"}");
-defer alloc.free(result);
+    const tools = try client.listTools();
+    defer alloc.free(tools);
+
+    const result = try client.callTool("read_file", "{\"path\":\"hello.txt\"}");
+    defer alloc.free(result);
+}
 ```
 
 ### One-shot convenience
@@ -262,8 +273,13 @@ defer alloc.free(result);
 const callOnce = @import("client.zig").callOnce;
 
 // Spawn → initialize → call → return → clean up, in one call
-const result = try callOnce(alloc, &.{"/path/to/server"}, "read_file", "{\"path\":\"hello.txt\"}");
-defer alloc.free(result);
+pub fn main(init: std.process.Init) !void {
+    const alloc = init.gpa;
+    const io = init.io;
+
+    const result = try callOnce(alloc, io, &.{"/path/to/server"}, "read_file", "{\"path\":\"hello.txt\"}");
+    defer alloc.free(result);
+}
 ```
 
 ### CLI example

--- a/build.zig
+++ b/build.zig
@@ -1,8 +1,22 @@
 const std = @import("std");
 
+const IoBackend = enum {
+    threaded,
+    evented,
+};
+
 pub fn build(b: *std.Build) void {
     const target   = b.standardTargetOptions(.{});
     const optimize = b.standardOptimizeOption(.{});
+    const requested_backend = b.option(
+        IoBackend,
+        "io-backend",
+        "Select std.Io backend for binaries: threaded or evented (Linux only for evented)",
+    ) orelse .threaded;
+    const evented_enabled = requested_backend == .evented and target.result.os.tag == .linux;
+
+    const build_options = b.addOptions();
+    build_options.addOption(bool, "evented_enabled", evented_enabled);
 
     // ── Library module (for consumers using mcp-zig as a dependency) ──────────
     _ = b.addModule("mcp", .{
@@ -18,10 +32,11 @@ pub fn build(b: *std.Build) void {
             .root_source_file = b.path("src/main.zig"),
             .target   = target,
             .optimize = optimize,
-            .single_threaded = true, // no TLS setup overhead
+            .single_threaded = !evented_enabled, // evented backend requires threaded runtime support
             .strip = true,           // smaller binary, faster page-in
         }),
     });
+    exe.root_module.addOptions("build_options", build_options);
     b.installArtifact(exe);
 
     // zig build run — start the server (useful for manual smoke-testing)
@@ -39,6 +54,7 @@ pub fn build(b: *std.Build) void {
             .optimize = optimize,
         }),
     });
+    client_exe.root_module.addOptions("build_options", build_options);
     b.installArtifact(client_exe);
 
     // zig build run-client -- /path/to/server

--- a/build.zig.zon
+++ b/build.zig.zon
@@ -2,7 +2,7 @@
     .name = .mcp_zig,
     .fingerprint = 0xad5eb907cca5f8fc,
     .version = "0.2.0",
-    .minimum_zig_version = "0.15.0",
+    .minimum_zig_version = "0.16.0",
     .dependencies = .{},
     .paths = .{
         "src",

--- a/src/client.zig
+++ b/src/client.zig
@@ -8,7 +8,7 @@
 // interleaved between the client's own request/response pairs.
 //
 // Usage:
-//   var client = try McpClient.init(alloc, &.{"/path/to/server"}, null);
+//   var client = try McpClient.init(alloc, io, &.{"/path/to/server"}, null);
 //   defer client.deinit();
 //   try client.initialize();
 //   const tools = try client.listTools();
@@ -19,39 +19,51 @@ const json = @import("json.zig");
 
 pub const McpClient = struct {
     alloc: std.mem.Allocator,
+    io: std.Io,
     process: std.process.Child,
     next_id: i64,
-    // Buffered reading state — avoids per-byte syscalls in readOneLine
-    stdout_buf: [4096]u8 = undefined,
-    stdout_pos: usize = 0,
-    stdout_len: usize = 0,
+    stdout_reader: std.Io.File.Reader,
+    stdout_buffer: []u8,
+    line_buf: std.ArrayList(u8) = .empty,
 
     pub fn init(
         alloc: std.mem.Allocator,
+        io: std.Io,
         argv: []const []const u8,
         cwd: ?[]const u8,
     ) !McpClient {
-        var child = std.process.Child.init(argv, alloc);
-        child.stdin_behavior = .Pipe;
-        child.stdout_behavior = .Pipe;
-        child.stderr_behavior = .Pipe;
-        if (cwd) |d| child.cwd = d;
-        try child.spawn();
+        const stdout_buffer = try alloc.alloc(u8, 4096);
+        errdefer alloc.free(stdout_buffer);
+
+        var child = try std.process.spawn(io, .{
+            .argv = argv,
+            .cwd = if (cwd) |d| .{ .path = d } else .inherit,
+            .stdin = .pipe,
+            .stdout = .pipe,
+            .stderr = .inherit,
+        });
+        errdefer child.kill(io);
+
         return .{
             .alloc = alloc,
+            .io = io,
             .process = child,
             .next_id = 1,
+            .stdout_reader = child.stdout.?.readerStreaming(io, stdout_buffer),
+            .stdout_buffer = stdout_buffer,
         };
     }
 
     pub fn deinit(self: *McpClient) void {
         // Close stdin first to signal the server to exit, then wait.
         // Don't close stdout/stderr manually — process.wait() handles cleanup.
-        if (self.process.stdin) |*s| {
-            s.close();
+        if (self.process.stdin) |stdin| {
+            stdin.close(self.io);
             self.process.stdin = null;
         }
-        _ = self.process.wait() catch {};
+        if (self.process.id != null) _ = self.process.wait(self.io) catch {};
+        self.line_buf.deinit(self.alloc);
+        self.alloc.free(self.stdout_buffer);
     }
 
     // ── High-level API ──────────────────────────────────────────────────────
@@ -68,7 +80,7 @@ pub const McpClient = struct {
     pub fn notifyInitialized(self: *McpClient) !void {
         const msg = "{\"jsonrpc\":\"2.0\",\"method\":\"notifications/initialized\"}\n";
         const stdin = self.process.stdin orelse return error.StdinClosed;
-        _ = try stdin.write(msg);
+        try stdin.writeStreamingAll(self.io, msg);
     }
 
     /// List available tools. Returns raw JSON result string.
@@ -100,7 +112,7 @@ pub const McpClient = struct {
         buf.appendSlice(self.alloc, "}}\n") catch return error.OutOfMemory;
 
         const stdin = self.process.stdin orelse return error.StdinClosed;
-        _ = try stdin.write(buf.items);
+        try stdin.writeStreamingAll(self.io, buf.items);
 
         return self.readResponse();
     }
@@ -137,7 +149,7 @@ pub const McpClient = struct {
         buf.append(self.alloc, '\n') catch return error.OutOfMemory;
 
         const stdin = self.process.stdin orelse return error.StdinClosed;
-        _ = try stdin.write(buf.items);
+        try stdin.writeStreamingAll(self.io, buf.items);
 
         return self.readResponse();
     }
@@ -161,57 +173,11 @@ pub const McpClient = struct {
     }
 
     /// Read exactly one newline-terminated line from the server's stdout.
-    /// Uses internal 4KB buffer to batch syscalls — typically 1 read per response
-    /// instead of 1 read per byte.
     fn readOneLine(self: *McpClient) ![]u8 {
-        const stdout = self.process.stdout orelse return error.StdoutClosed;
-
-        var line: std.ArrayList(u8) = .empty;
-        while (true) {
-            // Refill buffer if exhausted
-            if (self.stdout_pos >= self.stdout_len) {
-                const n = try stdout.read(&self.stdout_buf);
-                if (n == 0) {
-                    if (line.items.len > 0) {
-                        return line.toOwnedSlice(self.alloc) catch {
-                            line.deinit(self.alloc);
-                            return error.OutOfMemory;
-                        };
-                    }
-                    line.deinit(self.alloc);
-                    return error.ServerClosed;
-                }
-                self.stdout_pos = 0;
-                self.stdout_len = n;
-            }
-
-            // Scan for newline in buffered data
-            const remaining = self.stdout_buf[self.stdout_pos..self.stdout_len];
-            if (std.mem.indexOfScalar(u8, remaining, '\n')) |nl_pos| {
-                line.appendSlice(self.alloc, remaining[0..nl_pos]) catch {
-                    line.deinit(self.alloc);
-                    return error.OutOfMemory;
-                };
-                self.stdout_pos += nl_pos + 1;
-                break;
-            } else {
-                line.appendSlice(self.alloc, remaining) catch {
-                    line.deinit(self.alloc);
-                    return error.OutOfMemory;
-                };
-                self.stdout_pos = self.stdout_len;
-            }
-
-            if (line.items.len > json.MAX_LINE) {
-                line.deinit(self.alloc);
-                return error.ResponseTooLarge;
-            }
-        }
-
-        return line.toOwnedSlice(self.alloc) catch {
-            line.deinit(self.alloc);
-            return error.OutOfMemory;
-        };
+        const line = json.readLineInto(self.alloc, &self.stdout_reader.interface, &self.line_buf) orelse
+            return error.ServerClosed;
+        if (line.len > json.MAX_LINE) return error.ResponseTooLarge;
+        return self.alloc.dupe(u8, line);
     }
 
     /// If `line` is a server-to-client request (has "method" field), respond and return true.
@@ -248,22 +214,22 @@ pub const McpClient = struct {
         buf.appendSlice(self.alloc, ",\"result\":{\"roots\":[{\"uri\":\"file://") catch return;
 
         // Use cwd as the default root
-        var cwd_buf: [std.fs.max_path_bytes]u8 = undefined;
-        const cwd = std.fs.cwd().realpath(".", &cwd_buf) catch {
+        const cwd = std.process.currentPathAlloc(self.io, self.alloc) catch {
             // Fallback: empty roots
             buf.clearRetainingCapacity();
             buf.appendSlice(self.alloc, "{\"jsonrpc\":\"2.0\",\"id\":") catch return;
             appendId(self.alloc, &buf, id);
             buf.appendSlice(self.alloc, ",\"result\":{\"roots\":[]}}\n") catch return;
             const stdin = self.process.stdin orelse return;
-            _ = stdin.write(buf.items) catch {};
+            stdin.writeStreamingAll(self.io, buf.items) catch {};
             return;
         };
+        defer self.alloc.free(cwd);
         json.writeEscaped(self.alloc, &buf, cwd);
         buf.appendSlice(self.alloc, "\",\"name\":\"workspace\"}]}}\n") catch return;
 
         const stdin = self.process.stdin orelse return;
-        _ = stdin.write(buf.items) catch {};
+        stdin.writeStreamingAll(self.io, buf.items) catch {};
     }
 
     /// Send a JSON-RPC error response to the server.
@@ -282,7 +248,7 @@ pub const McpClient = struct {
         buf.appendSlice(self.alloc, "\"}}\n") catch return;
 
         const stdin = self.process.stdin orelse return;
-        _ = stdin.write(buf.items) catch {};
+        stdin.writeStreamingAll(self.io, buf.items) catch {};
     }
 
     fn appendId(alloc: std.mem.Allocator, buf: *std.ArrayList(u8), id: ?std.json.Value) void {
@@ -310,11 +276,12 @@ pub const McpClient = struct {
 /// Convenience for scripts that just need a single tool call.
 pub fn callOnce(
     alloc: std.mem.Allocator,
+    io: std.Io,
     server_argv: []const []const u8,
     tool_name: []const u8,
     args_json: []const u8,
 ) ![]u8 {
-    var client = try McpClient.init(alloc, server_argv, null);
+    var client = try McpClient.init(alloc, io, server_argv, null);
     defer client.deinit();
 
     const init_result = try client.initialize();

--- a/src/client_example.zig
+++ b/src/client_example.zig
@@ -6,19 +6,26 @@
 //        or:  zig-out/bin/mcp-client /path/to/server
 
 const std = @import("std");
+const Io = std.Io;
 const McpClient = @import("client.zig").McpClient;
 
-pub fn main() !void {
-    var gpa: std.heap.GeneralPurposeAllocator(.{}) = .{};
-    defer _ = gpa.deinit();
-    const alloc = gpa.allocator();
+pub fn main(init: std.process.Init) !void {
+    const alloc = init.gpa;
+    const io = init.io;
+    const arena = init.arena.allocator();
 
-    const args = try std.process.argsAlloc(alloc);
-    defer std.process.argsFree(alloc, args);
+    var stdout_buffer: [4096]u8 = undefined;
+    var stdout_writer = Io.File.stdout().writer(io, &stdout_buffer);
+    const stdout = &stdout_writer.interface;
+
+    var stderr_buffer: [4096]u8 = undefined;
+    var stderr_writer = Io.File.stderr().writer(io, &stderr_buffer);
+    const stderr = &stderr_writer.interface;
+
+    const args = try init.minimal.args.toSlice(arena);
 
     if (args.len < 2) {
-        const stderr = std.fs.File.stderr().deprecatedWriter();
-        stderr.print(
+        try stderr.print(
             \\mcp-client — MCP client example
             \\
             \\Usage: mcp-client <server-path> [tool-name] [args-json]
@@ -27,7 +34,8 @@ pub fn main() !void {
             \\  mcp-client ./zig-out/bin/mcp-zig
             \\  mcp-client ./zig-out/bin/mcp-zig read_file '{{"path":"README.md"}}'
             \\
-        , .{}) catch {};
+        , .{});
+        try stderr.flush();
         return;
     }
 
@@ -35,36 +43,35 @@ pub fn main() !void {
     const tool_name = if (args.len > 2) args[2] else null;
     const tool_args = if (args.len > 3) args[3] else "{}";
 
-    const stdout = std.fs.File.stdout().deprecatedWriter();
-
     // Spawn server
-    var client = try McpClient.init(alloc, &.{server_path}, null);
+    var client = try McpClient.init(alloc, io, &.{server_path}, null);
     defer client.deinit();
 
     // Initialize
-    stdout.print("→ initialize\n", .{}) catch {};
+    try stdout.print("→ initialize\n", .{});
     const init_result = try client.initialize();
     defer alloc.free(init_result);
-    stdout.print("← {s}\n\n", .{init_result}) catch {};
+    try stdout.print("← {s}\n\n", .{init_result});
 
     try client.notifyInitialized();
 
     // List tools
-    stdout.print("→ tools/list\n", .{}) catch {};
+    try stdout.print("→ tools/list\n", .{});
     const tools_result = try client.listTools();
     defer alloc.free(tools_result);
-    stdout.print("← {s}\n\n", .{tools_result}) catch {};
+    try stdout.print("← {s}\n\n", .{tools_result});
 
     // Call tool (if specified)
     if (tool_name) |name| {
-        stdout.print("→ tools/call: {s}({s})\n", .{ name, tool_args }) catch {};
+        try stdout.print("→ tools/call: {s}({s})\n", .{ name, tool_args });
         const call_result = try client.callTool(name, tool_args);
         defer alloc.free(call_result);
-        stdout.print("← {s}\n", .{call_result}) catch {};
+        try stdout.print("← {s}\n", .{call_result});
     }
 
     // Ping
-    stdout.print("\n→ ping\n", .{}) catch {};
+    try stdout.print("\n→ ping\n", .{});
     const alive = try client.ping();
-    stdout.print("← pong: {}\n", .{alive}) catch {};
+    try stdout.print("← pong: {}\n", .{alive});
+    try stdout.flush();
 }

--- a/src/client_example.zig
+++ b/src/client_example.zig
@@ -6,13 +6,17 @@
 //        or:  zig-out/bin/mcp-client /path/to/server
 
 const std = @import("std");
-const Io = std.Io;
 const McpClient = @import("client.zig").McpClient;
+const runtime = @import("runtime.zig");
 
 pub fn main(init: std.process.Init) !void {
     const alloc = init.gpa;
-    const io = init.io;
     const arena = init.arena.allocator();
+    var rt = try runtime.Runtime.init(alloc, init);
+    defer rt.deinit();
+    const io = rt.io();
+
+    const Io = std.Io;
 
     var stdout_buffer: [4096]u8 = undefined;
     var stdout_writer = Io.File.stdout().writer(io, &stdout_buffer);

--- a/src/json.zig
+++ b/src/json.zig
@@ -342,22 +342,10 @@ pub fn scanHasKey(data: []const u8, key: []const u8) bool {
 
 /// Legacy API — reads one byte at a time from the raw file handle.
 /// Prefer readLineBuf with a File.Reader for better performance.
-pub fn readLine(alloc: std.mem.Allocator, file: std.fs.File) ?[]u8 {
-    var line: std.ArrayList(u8) = .empty;
-    var buf: [1]u8 = undefined;
-    while (true) {
-        const n = file.read(&buf) catch {
-            line.deinit(alloc);
-            return null;
-        };
-        if (n == 0) {
-            if (line.items.len == 0) { line.deinit(alloc); return null; }
-            return line.toOwnedSlice(alloc) catch null;
-        }
-        if (buf[0] == '\n') return line.toOwnedSlice(alloc) catch null;
-        line.append(alloc, buf[0]) catch { line.deinit(alloc); return null; };
-        if (line.items.len > MAX_LINE) { line.deinit(alloc); return null; }
-    }
+pub fn readLine(alloc: std.mem.Allocator, io: std.Io, file: std.Io.File) ?[]u8 {
+    var read_buf: [256]u8 = undefined;
+    var reader = file.readerStreaming(io, &read_buf);
+    return readLineBuf(alloc, &reader.interface);
 }
 
 // ── Field extraction ──────────────────────────────────────────────────────────

--- a/src/main.zig
+++ b/src/main.zig
@@ -12,7 +12,11 @@
 
 const std = @import("std");
 const mcp = @import("mcp.zig");
+const runtime = @import("runtime.zig");
 
-pub fn main(init: std.process.Init) void {
-    mcp.run(init.arena.allocator(), init.io);
+pub fn main(init: std.process.Init) !void {
+    var rt = try runtime.Runtime.init(init.gpa, init);
+    defer rt.deinit();
+
+    mcp.run(init.arena.allocator(), rt.io());
 }

--- a/src/main.zig
+++ b/src/main.zig
@@ -13,9 +13,6 @@
 const std = @import("std");
 const mcp = @import("mcp.zig");
 
-pub fn main() void {
-    // Arena over page_allocator: one mmap up front, then O(1) bump allocation.
-    // No per-allocation syscalls, no free overhead — ideal for a short-lived process.
-    var arena = std.heap.ArenaAllocator.init(std.heap.page_allocator);
-    mcp.run(arena.allocator());
+pub fn main(init: std.process.Init) void {
+    mcp.run(init.arena.allocator(), init.io);
 }

--- a/src/mcp.zig
+++ b/src/mcp.zig
@@ -60,7 +60,8 @@ pub const Root = struct {
 /// MCP session state — tracks client capabilities, workspace roots, and log level.
 const Session = struct {
     alloc: std.mem.Allocator,
-    stdout: std.fs.File,
+    io: std.Io,
+    stdout: std.Io.File,
     next_id: i64 = 100, // start high to avoid collision with client IDs
 
     // Client capabilities (parsed from initialize request)
@@ -99,14 +100,15 @@ const Session = struct {
     }
 };
 
-pub fn run(alloc: std.mem.Allocator) void {
+pub fn run(alloc: std.mem.Allocator, io: std.Io) void {
     var session: Session = .{
         .alloc = alloc,
-        .stdout = std.fs.File.stdout(),
+        .io = io,
+        .stdout = std.Io.File.stdout(),
     };
     defer session.deinit();
     var read_buf: [4096]u8 = undefined;
-    var stdin_reader = std.fs.File.stdin().reader(&read_buf);
+    var stdin_reader = std.Io.File.stdin().readerStreaming(io, &read_buf);
 
     // Comptime perfect-hash method dispatch table — O(1) lookup, no sequential string comparisons.
     const Method = enum { ping, tools_list, tools_call, initialize, logging_setLevel, notif_initialized, notif_roots_changed, notif_cancelled };
@@ -185,7 +187,7 @@ fn handleCall(
 
     // Run handler into reusable tool_buf (clear, not free)
     s.tool_buf.clearRetainingCapacity();
-    tools.dispatchFast(alloc, tool, args_raw, &s.tool_buf);
+    tools.dispatchFast(alloc, s.io, tool, args_raw, &s.tool_buf);
 
     // Build the complete JSON-RPC response directly into write_buf.
     const buf = &s.write_buf;
@@ -206,7 +208,7 @@ fn handleCall(
     }
 
     buf.appendSlice(alloc, "}}\n") catch return;
-    _ = s.stdout.write(buf.items) catch 0;
+    s.stdout.writeStreamingAll(s.io, buf.items) catch {};
 }
 
 // ── initialize ─────────────────────────────────────────────────────────────
@@ -424,7 +426,7 @@ fn writeResultRaw(s: *Session, id_raw: ?[]const u8, result: []const u8) void {
     buf.appendSlice(alloc, ",\"result\":") catch return;
     appendStrippingNewlines(alloc, buf, result);
     buf.appendSlice(alloc, "}\n") catch return;
-    _ = s.stdout.write(buf.items) catch 0;
+    s.stdout.writeStreamingAll(s.io, buf.items) catch {};
 }
 
 /// Write an error response using a raw id string (from scanner — avoids JSON parse).
@@ -441,7 +443,7 @@ fn writeErrorRaw(s: *Session, id_raw: ?[]const u8, code: i32, msg: []const u8) v
     buf.appendSlice(alloc, ",\"message\":\"") catch return;
     json.writeEscaped(alloc, buf, msg);
     buf.appendSlice(alloc, "\"}}\n") catch return;
-    _ = s.stdout.write(buf.items) catch 0;
+    s.stdout.writeStreamingAll(s.io, buf.items) catch {};
 }
 
 /// Write a JSON-RPC 2.0 result response.
@@ -455,7 +457,7 @@ fn writeResult(s: *Session, id: ?std.json.Value, result: []const u8) void {
     buf.appendSlice(alloc, ",\"result\":") catch return;
     appendStrippingNewlines(alloc, buf, result);
     buf.appendSlice(alloc, "}\n") catch return;
-    _ = s.stdout.write(buf.items) catch 0;
+    s.stdout.writeStreamingAll(s.io, buf.items) catch {};
 }
 
 /// Write a JSON-RPC 2.0 error response.
@@ -472,7 +474,7 @@ fn writeError(s: *Session, id: ?std.json.Value, code: i32, msg: []const u8) void
     buf.appendSlice(alloc, ",\"message\":\"") catch return;
     json.writeEscaped(alloc, buf, msg);
     buf.appendSlice(alloc, "\"}}\n") catch return;
-    _ = s.stdout.write(buf.items) catch 0;
+    s.stdout.writeStreamingAll(s.io, buf.items) catch {};
 }
 
 /// Write a JSON-RPC 2.0 notification (no id, no response expected).
@@ -486,7 +488,7 @@ fn writeNotification(s: *Session, method: []const u8, params: []const u8) void {
     buf.appendSlice(alloc, "\",\"params\":") catch return;
     appendStrippingNewlines(alloc, buf, params);
     buf.appendSlice(alloc, "}\n") catch return;
-    _ = s.stdout.write(buf.items) catch 0;
+    s.stdout.writeStreamingAll(s.io, buf.items) catch {};
 }
 
 /// Write a JSON-RPC 2.0 request (server → client).
@@ -503,7 +505,7 @@ fn writeRequest(s: *Session, id: i64, method: []const u8, params: []const u8) vo
     buf.appendSlice(alloc, "\",\"params\":") catch return;
     buf.appendSlice(alloc, params) catch return;
     buf.appendSlice(alloc, "}\n") catch return;
-    _ = s.stdout.write(buf.items) catch 0;
+    s.stdout.writeStreamingAll(s.io, buf.items) catch {};
 }
 
 /// Append data to buf, skipping \n and \r characters.

--- a/src/runtime.zig
+++ b/src/runtime.zig
@@ -1,0 +1,48 @@
+const std = @import("std");
+const build_options = @import("build_options");
+
+const UseEvented = build_options.evented_enabled;
+
+pub const Backend = enum {
+    threaded,
+    evented,
+};
+
+const Impl = if (UseEvented) ?std.Io.Evented else void;
+
+pub const Runtime = struct {
+    io_handle: std.Io,
+    impl: Impl = if (UseEvented) null else {},
+
+    pub fn init(gpa: std.mem.Allocator, init_ctx: std.process.Init) !Runtime {
+        if (UseEvented) {
+            var evented: std.Io.Evented = undefined;
+            try evented.init(gpa, .{
+                .argv0 = std.Io.Threaded.Argv0.init(init_ctx.minimal.args),
+                .environ = init_ctx.minimal.environ,
+            });
+            return .{
+                .io_handle = evented.io(),
+                .impl = evented,
+            };
+        }
+
+        return .{ .io_handle = init_ctx.io };
+    }
+
+    pub fn deinit(self: *Runtime) void {
+        if (UseEvented) {
+            self.impl.?.deinit();
+        }
+    }
+
+    pub fn io(self: *const Runtime) std.Io {
+        return self.io_handle;
+    }
+
+    pub fn backend(self: *const Runtime) Backend {
+        _ = self;
+        if (UseEvented) return .evented;
+        return .threaded;
+    }
+};

--- a/src/tools.zig
+++ b/src/tools.zig
@@ -46,13 +46,14 @@ pub fn parse(name: []const u8) ?Tool {
 
 pub fn dispatch(
     alloc: std.mem.Allocator,
+    io: std.Io,
     tool: Tool,
     args: *const std.json.ObjectMap,
     out: *std.ArrayList(u8),
 ) void {
     switch (tool) {
-        .read_file => handleReadFile(alloc, args, out),
-        .list_dir  => handleListDir(alloc, args, out),
+        .read_file => handleReadFile(alloc, io, args, out),
+        .list_dir  => handleListDir(alloc, io, args, out),
         // .add_your_tool_here => handleYourTool(alloc, args, out),
     }
 }
@@ -61,17 +62,50 @@ pub fn dispatch(
 /// Extracts fields directly from the raw JSON string with zero allocations.
 pub fn dispatchFast(
     alloc: std.mem.Allocator,
+    io: std.Io,
     tool: Tool,
     args_raw: []const u8,
     out: *std.ArrayList(u8),
 ) void {
     switch (tool) {
-        .read_file => handleReadFileFast(alloc, args_raw, out),
-        .list_dir  => handleListDirFast(alloc, args_raw, out),
+        .read_file => handleReadFileFast(alloc, io, args_raw, out),
+        .list_dir  => handleListDirFast(alloc, io, args_raw, out),
     }
 }
 
-fn handleReadFileFast(alloc: std.mem.Allocator, args_raw: []const u8, out: *std.ArrayList(u8)) void {
+fn appendFileContents(
+    alloc: std.mem.Allocator,
+    io: std.Io,
+    path: []const u8,
+    max_bytes: usize,
+    out: *std.ArrayList(u8),
+) void {
+    var file = std.Io.Dir.cwd().openFile(io, path, .{ .allow_directory = false }) catch |err| {
+        var tmp: [512]u8 = undefined;
+        const s = std.fmt.bufPrint(&tmp, "error opening '{s}': {s}", .{ path, @errorName(err) }) catch return;
+        out.appendSlice(alloc, s) catch {};
+        return;
+    };
+    defer file.close(io);
+
+    const start = out.items.len;
+    out.ensureUnusedCapacity(alloc, max_bytes) catch {
+        out.appendSlice(alloc, "error: out of memory") catch {};
+        return;
+    };
+    out.items.len += max_bytes;
+
+    const n = file.readPositionalAll(io, out.items[start..], 0) catch |err| {
+        var tmp: [512]u8 = undefined;
+        const s = std.fmt.bufPrint(&tmp, "error reading '{s}': {s}", .{ path, @errorName(err) }) catch return;
+        out.items.len = start;
+        out.appendSlice(alloc, s) catch {};
+        return;
+    };
+    out.items.len = start + n;
+}
+
+fn handleReadFileFast(alloc: std.mem.Allocator, io: std.Io, args_raw: []const u8, out: *std.ArrayList(u8)) void {
     const path = json.scanStr(args_raw, "path") orelse {
         out.appendSlice(alloc, "error: missing 'path' argument") catch {};
         return;
@@ -81,53 +115,29 @@ fn handleReadFileFast(alloc: std.mem.Allocator, args_raw: []const u8, out: *std.
     else
         DEFAULT_MAX_BYTES;
 
-    const file = std.fs.cwd().openFile(path, .{}) catch |err| {
-        var tmp: [512]u8 = undefined;
-        const s = std.fmt.bufPrint(&tmp, "error opening '{s}': {s}", .{ path, @errorName(err) }) catch return;
-        out.appendSlice(alloc, s) catch {};
-        return;
-    };
-    defer file.close();
-
-    out.ensureTotalCapacity(alloc, max_bytes) catch {
-        out.appendSlice(alloc, "error: out of memory") catch {};
-        return;
-    };
-    while (out.items.len < max_bytes) {
-        const buf = out.unusedCapacitySlice();
-        if (buf.len == 0) break;
-        const n = file.read(buf) catch |err| {
-            var tmp: [512]u8 = undefined;
-            const s = std.fmt.bufPrint(&tmp, "error reading '{s}': {s}", .{ path, @errorName(err) }) catch return;
-            out.clearRetainingCapacity();
-            out.appendSlice(alloc, s) catch {};
-            return;
-        };
-        if (n == 0) break;
-        out.items.len += n;
-    }
+    appendFileContents(alloc, io, path, max_bytes, out);
 }
 
-fn handleListDirFast(alloc: std.mem.Allocator, args_raw: []const u8, out: *std.ArrayList(u8)) void {
+fn handleListDirFast(alloc: std.mem.Allocator, io: std.Io, args_raw: []const u8, out: *std.ArrayList(u8)) void {
     const path = json.scanStr(args_raw, "path") orelse ".";
 
-    var dir = std.fs.cwd().openDir(path, .{ .iterate = true }) catch |err| {
+    var dir = std.Io.Dir.cwd().openDir(io, path, .{ .iterate = true }) catch |err| {
         var tmp: [512]u8 = undefined;
         const s = std.fmt.bufPrint(&tmp, "error opening '{s}': {s}", .{ path, @errorName(err) }) catch return;
         out.appendSlice(alloc, s) catch {};
         return;
     };
-    defer dir.close();
+    defer dir.close(io);
 
     var it = dir.iterate();
-    while (it.next() catch null) |entry| {
+    while (it.next(io) catch null) |entry| {
         const kind: u8 = switch (entry.kind) {
             .directory => 'd',
             .file      => 'f',
             .sym_link  => 'l',
             else       => '?',
         };
-        var line: [std.fs.max_path_bytes + 4]u8 = undefined;
+        var line: [std.Io.Dir.max_path_bytes + 4]u8 = undefined;
         const s = std.fmt.bufPrint(&line, "{c} {s}\n", .{ kind, entry.name }) catch continue;
         out.appendSlice(alloc, s) catch {};
     }
@@ -139,6 +149,7 @@ const DEFAULT_MAX_BYTES = 1024 * 1024; // 1 MB
 
 fn handleReadFile(
     alloc: std.mem.Allocator,
+    io: std.Io,
     args: *const std.json.ObjectMap,
     out: *std.ArrayList(u8),
 ) void {
@@ -151,60 +162,34 @@ fn handleReadFile(
     else
         DEFAULT_MAX_BYTES;
 
-    const file = std.fs.cwd().openFile(path, .{}) catch |err| {
-        var tmp: [512]u8 = undefined;
-        const s = std.fmt.bufPrint(&tmp, "error opening '{s}': {s}", .{ path, @errorName(err) }) catch return;
-        out.appendSlice(alloc, s) catch {};
-        return;
-    };
-    defer file.close();
-
-    // Read directly into the output buffer to avoid a temporary allocation + copy.
-    // Reserve space up front, then read into the unused tail of the ArrayList.
-    out.ensureTotalCapacity(alloc, max_bytes) catch {
-        out.appendSlice(alloc, "error: out of memory") catch {};
-        return;
-    };
-    while (out.items.len < max_bytes) {
-        const buf = out.unusedCapacitySlice();
-        if (buf.len == 0) break;
-        const n = file.read(buf) catch |err| {
-            var tmp: [512]u8 = undefined;
-            const s = std.fmt.bufPrint(&tmp, "error reading '{s}': {s}", .{ path, @errorName(err) }) catch return;
-            // Reset output, write error instead
-            out.clearRetainingCapacity();
-            out.appendSlice(alloc, s) catch {};
-            return;
-        };
-        if (n == 0) break;
-        out.items.len += n;
-    }
+    appendFileContents(alloc, io, path, max_bytes, out);
 }
 
 fn handleListDir(
     alloc: std.mem.Allocator,
+    io: std.Io,
     args: *const std.json.ObjectMap,
     out: *std.ArrayList(u8),
 ) void {
     const path = json.getStr(args, "path") orelse ".";
 
-    var dir = std.fs.cwd().openDir(path, .{ .iterate = true }) catch |err| {
+    var dir = std.Io.Dir.cwd().openDir(io, path, .{ .iterate = true }) catch |err| {
         var tmp: [512]u8 = undefined;
         const s = std.fmt.bufPrint(&tmp, "error opening '{s}': {s}", .{ path, @errorName(err) }) catch return;
         out.appendSlice(alloc, s) catch {};
         return;
     };
-    defer dir.close();
+    defer dir.close(io);
 
     var it = dir.iterate();
-    while (it.next() catch null) |entry| {
+    while (it.next(io) catch null) |entry| {
         const kind: u8 = switch (entry.kind) {
             .directory => 'd',
             .file      => 'f',
             .sym_link  => 'l',
             else       => '?',
         };
-        var line: [std.fs.max_path_bytes + 4]u8 = undefined;
+        var line: [std.Io.Dir.max_path_bytes + 4]u8 = undefined;
         const s = std.fmt.bufPrint(&line, "{c} {s}\n", .{ kind, entry.name }) catch continue;
         out.appendSlice(alloc, s) catch {};
     }

--- a/src/tools.zig
+++ b/src/tools.zig
@@ -19,6 +19,7 @@ const json = @import("json.zig");
 pub const Tool = enum {
     read_file,
     list_dir,
+    batch,
     // add_your_tool_here,
 };
 
@@ -30,7 +31,8 @@ pub const Tool = enum {
 pub const tools_list =
     \\{"tools":[
     \\{"name":"read_file","description":"Read a file from the filesystem and return its contents as text.","inputSchema":{"type":"object","properties":{"path":{"type":"string","description":"Absolute or relative path to the file"},"max_bytes":{"type":"integer","description":"Maximum bytes to read (default: 1MB)"}},"required":["path"]}},
-    \\{"name":"list_dir","description":"List files and directories at a path.","inputSchema":{"type":"object","properties":{"path":{"type":"string","description":"Directory path to list (default: current directory)"}},"required":[]}}
+    \\{"name":"list_dir","description":"List files and directories at a path.","inputSchema":{"type":"object","properties":{"path":{"type":"string","description":"Directory path to list (default: current directory)"}},"required":[]}},
+    \\{"name":"batch","description":"Run multiple read_file or list_dir operations in one tool call and return ordered per-item results.","inputSchema":{"type":"object","properties":{"operations":{"type":"array","description":"Operations to execute in order.","items":{"type":"object","properties":{"tool":{"type":"string","enum":["read_file","list_dir"],"description":"Nested tool to execute."},"arguments":{"type":"object","description":"Arguments for the nested tool."}},"required":["tool","arguments"]}}},"required":["operations"]}}
     \\]}
 ;
 
@@ -51,11 +53,7 @@ pub fn dispatch(
     args: *const std.json.ObjectMap,
     out: *std.ArrayList(u8),
 ) void {
-    switch (tool) {
-        .read_file => handleReadFile(alloc, io, args, out),
-        .list_dir  => handleListDir(alloc, io, args, out),
-        // .add_your_tool_here => handleYourTool(alloc, args, out),
-    }
+    _ = dispatchResult(alloc, io, tool, args, out);
 }
 
 /// Fast dispatch using raw JSON arguments (no std.json tree needed).
@@ -67,10 +65,35 @@ pub fn dispatchFast(
     args_raw: []const u8,
     out: *std.ArrayList(u8),
 ) void {
-    switch (tool) {
+    _ = dispatchFastResult(alloc, io, tool, args_raw, out);
+}
+
+fn dispatchResult(
+    alloc: std.mem.Allocator,
+    io: std.Io,
+    tool: Tool,
+    args: *const std.json.ObjectMap,
+    out: *std.ArrayList(u8),
+) bool {
+    return switch (tool) {
+        .read_file => handleReadFile(alloc, io, args, out),
+        .list_dir  => handleListDir(alloc, io, args, out),
+        .batch     => handleBatch(alloc, io, args, out),
+    };
+}
+
+fn dispatchFastResult(
+    alloc: std.mem.Allocator,
+    io: std.Io,
+    tool: Tool,
+    args_raw: []const u8,
+    out: *std.ArrayList(u8),
+) bool {
+    return switch (tool) {
         .read_file => handleReadFileFast(alloc, io, args_raw, out),
         .list_dir  => handleListDirFast(alloc, io, args_raw, out),
-    }
+        .batch     => handleBatchFast(alloc, io, args_raw, out),
+    };
 }
 
 fn appendFileContents(
@@ -79,53 +102,49 @@ fn appendFileContents(
     path: []const u8,
     max_bytes: usize,
     out: *std.ArrayList(u8),
-) void {
+) bool {
     var file = std.Io.Dir.cwd().openFile(io, path, .{ .allow_directory = false }) catch |err| {
         var tmp: [512]u8 = undefined;
-        const s = std.fmt.bufPrint(&tmp, "error opening '{s}': {s}", .{ path, @errorName(err) }) catch return;
+        const s = std.fmt.bufPrint(&tmp, "error opening '{s}': {s}", .{ path, @errorName(err) }) catch "error opening file";
         out.appendSlice(alloc, s) catch {};
-        return;
+        return false;
     };
     defer file.close(io);
 
-    const start = out.items.len;
-    out.ensureUnusedCapacity(alloc, max_bytes) catch {
-        out.appendSlice(alloc, "error: out of memory") catch {};
-        return;
+    const reserve_len = blk: {
+        const stat = file.stat(io) catch break :blk max_bytes;
+        break :blk @min(max_bytes, std.math.cast(usize, stat.size) orelse max_bytes);
     };
-    out.items.len += max_bytes;
+
+    const start = out.items.len;
+    out.ensureUnusedCapacity(alloc, reserve_len) catch {
+        out.appendSlice(alloc, "error: out of memory") catch {};
+        return false;
+    };
+    out.items.len += reserve_len;
 
     const n = file.readPositionalAll(io, out.items[start..], 0) catch |err| {
         var tmp: [512]u8 = undefined;
-        const s = std.fmt.bufPrint(&tmp, "error reading '{s}': {s}", .{ path, @errorName(err) }) catch return;
+        const s = std.fmt.bufPrint(&tmp, "error reading '{s}': {s}", .{ path, @errorName(err) }) catch "error reading file";
         out.items.len = start;
         out.appendSlice(alloc, s) catch {};
-        return;
+        return false;
     };
     out.items.len = start + n;
+    return true;
 }
 
-fn handleReadFileFast(alloc: std.mem.Allocator, io: std.Io, args_raw: []const u8, out: *std.ArrayList(u8)) void {
-    const path = json.scanStr(args_raw, "path") orelse {
-        out.appendSlice(alloc, "error: missing 'path' argument") catch {};
-        return;
-    };
-    const max_bytes: usize = if (json.scanInt(args_raw, "max_bytes")) |n|
-        @intCast(@max(1, n))
-    else
-        DEFAULT_MAX_BYTES;
-
-    appendFileContents(alloc, io, path, max_bytes, out);
-}
-
-fn handleListDirFast(alloc: std.mem.Allocator, io: std.Io, args_raw: []const u8, out: *std.ArrayList(u8)) void {
-    const path = json.scanStr(args_raw, "path") orelse ".";
-
+fn appendDirEntries(
+    alloc: std.mem.Allocator,
+    io: std.Io,
+    path: []const u8,
+    out: *std.ArrayList(u8),
+) bool {
     var dir = std.Io.Dir.cwd().openDir(io, path, .{ .iterate = true }) catch |err| {
         var tmp: [512]u8 = undefined;
-        const s = std.fmt.bufPrint(&tmp, "error opening '{s}': {s}", .{ path, @errorName(err) }) catch return;
+        const s = std.fmt.bufPrint(&tmp, "error opening '{s}': {s}", .{ path, @errorName(err) }) catch "error opening directory";
         out.appendSlice(alloc, s) catch {};
-        return;
+        return false;
     };
     defer dir.close(io);
 
@@ -139,8 +158,144 @@ fn handleListDirFast(alloc: std.mem.Allocator, io: std.Io, args_raw: []const u8,
         };
         var line: [std.Io.Dir.max_path_bytes + 4]u8 = undefined;
         const s = std.fmt.bufPrint(&line, "{c} {s}\n", .{ kind, entry.name }) catch continue;
-        out.appendSlice(alloc, s) catch {};
+        out.appendSlice(alloc, s) catch return false;
     }
+    return true;
+}
+
+fn appendJsonString(alloc: std.mem.Allocator, out: *std.ArrayList(u8), s: []const u8) void {
+    out.append(alloc, '"') catch return;
+    json.writeEscaped(alloc, out, s);
+    out.append(alloc, '"') catch return;
+}
+
+fn appendBatchTopLevelError(alloc: std.mem.Allocator, out: *std.ArrayList(u8), msg: []const u8) bool {
+    out.appendSlice(alloc, "{\"results\":[],\"error\":") catch return false;
+    appendJsonString(alloc, out, msg);
+    out.append(alloc, '}') catch return false;
+    return false;
+}
+
+fn appendBatchResult(
+    alloc: std.mem.Allocator,
+    out: *std.ArrayList(u8),
+    index: usize,
+    tool_name: ?[]const u8,
+    ok: bool,
+    payload: []const u8,
+) void {
+    var num_buf: [20]u8 = undefined;
+    const index_str = std.fmt.bufPrint(&num_buf, "{d}", .{index}) catch return;
+
+    out.appendSlice(alloc, "{\"index\":") catch return;
+    out.appendSlice(alloc, index_str) catch return;
+    out.appendSlice(alloc, ",\"tool\":") catch return;
+    if (tool_name) |name| {
+        appendJsonString(alloc, out, name);
+    } else {
+        out.appendSlice(alloc, "null") catch return;
+    }
+    out.appendSlice(alloc, ",\"ok\":") catch return;
+    out.appendSlice(alloc, if (ok) "true" else "false") catch return;
+    out.appendSlice(alloc, if (ok) ",\"text\":" else ",\"error\":") catch return;
+    appendJsonString(alloc, out, payload);
+    out.append(alloc, '}') catch return;
+}
+
+fn handleBatchFast(
+    alloc: std.mem.Allocator,
+    io: std.Io,
+    args_raw: []const u8,
+    out: *std.ArrayList(u8),
+) bool {
+    var arena = std.heap.ArenaAllocator.init(std.heap.page_allocator);
+    defer arena.deinit();
+
+    const parsed = std.json.parseFromSlice(std.json.Value, arena.allocator(), args_raw, .{}) catch {
+        return appendBatchTopLevelError(alloc, out, "invalid batch arguments");
+    };
+
+    if (parsed.value != .object) {
+        return appendBatchTopLevelError(alloc, out, "batch arguments must be an object");
+    }
+
+    return handleBatch(alloc, io, &parsed.value.object, out);
+}
+
+fn handleBatch(
+    alloc: std.mem.Allocator,
+    io: std.Io,
+    args: *const std.json.ObjectMap,
+    out: *std.ArrayList(u8),
+) bool {
+    const operations_val = args.get("operations") orelse {
+        return appendBatchTopLevelError(alloc, out, "missing 'operations' argument");
+    };
+    if (operations_val != .array) {
+        return appendBatchTopLevelError(alloc, out, "'operations' must be an array");
+    }
+
+    var item_buf: std.ArrayList(u8) = .empty;
+    defer item_buf.deinit(std.heap.page_allocator);
+
+    out.appendSlice(alloc, "{\"results\":[") catch return false;
+
+    for (operations_val.array.items, 0..) |op_val, index| {
+        if (index != 0) out.append(alloc, ',') catch return false;
+
+        if (op_val != .object) {
+            appendBatchResult(alloc, out, index, null, false, "operation must be an object");
+            continue;
+        }
+
+        var op_obj = op_val.object;
+        const tool_name = json.getStr(&op_obj, "tool") orelse {
+            appendBatchResult(alloc, out, index, null, false, "missing 'tool'");
+            continue;
+        };
+        const nested_tool = parse(tool_name) orelse {
+            appendBatchResult(alloc, out, index, tool_name, false, "unknown tool");
+            continue;
+        };
+        if (nested_tool == .batch) {
+            appendBatchResult(alloc, out, index, tool_name, false, "nested batch is not supported");
+            continue;
+        }
+
+        const nested_args_val = op_obj.get("arguments") orelse {
+            appendBatchResult(alloc, out, index, tool_name, false, "missing 'arguments'");
+            continue;
+        };
+        if (nested_args_val != .object) {
+            appendBatchResult(alloc, out, index, tool_name, false, "'arguments' must be an object");
+            continue;
+        }
+
+        item_buf.clearRetainingCapacity();
+        const ok = dispatchResult(std.heap.page_allocator, io, nested_tool, &nested_args_val.object, &item_buf);
+        appendBatchResult(alloc, out, index, tool_name, ok, item_buf.items);
+    }
+
+    out.appendSlice(alloc, "]}") catch return false;
+    return true;
+}
+
+fn handleReadFileFast(alloc: std.mem.Allocator, io: std.Io, args_raw: []const u8, out: *std.ArrayList(u8)) bool {
+    const path = json.scanStr(args_raw, "path") orelse {
+        out.appendSlice(alloc, "error: missing 'path' argument") catch {};
+        return false;
+    };
+    const max_bytes: usize = if (json.scanInt(args_raw, "max_bytes")) |n|
+        @intCast(@max(1, n))
+    else
+        DEFAULT_MAX_BYTES;
+
+    return appendFileContents(alloc, io, path, max_bytes, out);
+}
+
+fn handleListDirFast(alloc: std.mem.Allocator, io: std.Io, args_raw: []const u8, out: *std.ArrayList(u8)) bool {
+    const path = json.scanStr(args_raw, "path") orelse ".";
+    return appendDirEntries(alloc, io, path, out);
 }
 
 // ── Handlers ──────────────────────────────────────────────────────────────────
@@ -152,17 +307,17 @@ fn handleReadFile(
     io: std.Io,
     args: *const std.json.ObjectMap,
     out: *std.ArrayList(u8),
-) void {
+) bool {
     const path = json.getStr(args, "path") orelse {
         out.appendSlice(alloc, "error: missing 'path' argument") catch {};
-        return;
+        return false;
     };
     const max_bytes: usize = if (json.getInt(args, "max_bytes")) |n|
         @intCast(@max(1, n))
     else
         DEFAULT_MAX_BYTES;
 
-    appendFileContents(alloc, io, path, max_bytes, out);
+    return appendFileContents(alloc, io, path, max_bytes, out);
 }
 
 fn handleListDir(
@@ -170,27 +325,7 @@ fn handleListDir(
     io: std.Io,
     args: *const std.json.ObjectMap,
     out: *std.ArrayList(u8),
-) void {
+) bool {
     const path = json.getStr(args, "path") orelse ".";
-
-    var dir = std.Io.Dir.cwd().openDir(io, path, .{ .iterate = true }) catch |err| {
-        var tmp: [512]u8 = undefined;
-        const s = std.fmt.bufPrint(&tmp, "error opening '{s}': {s}", .{ path, @errorName(err) }) catch return;
-        out.appendSlice(alloc, s) catch {};
-        return;
-    };
-    defer dir.close(io);
-
-    var it = dir.iterate();
-    while (it.next(io) catch null) |entry| {
-        const kind: u8 = switch (entry.kind) {
-            .directory => 'd',
-            .file      => 'f',
-            .sym_link  => 'l',
-            else       => '?',
-        };
-        var line: [std.Io.Dir.max_path_bytes + 4]u8 = undefined;
-        const s = std.fmt.bufPrint(&line, "{c} {s}\n", .{ kind, entry.name }) catch continue;
-        out.appendSlice(alloc, s) catch {};
-    }
+    return appendDirEntries(alloc, io, path, out);
 }


### PR DESCRIPTION
# Zig 0.16.0 Migration Tracking Issue

## Summary
Zig 0.16.0 introduces significant breaking changes that require updates throughout mcp-zig. This issue tracks all the changes needed for full compatibility.

## Breaking Changes & Fixes

### 1. **File I/O (`std.fs.File` → `std.Io.File`)**
- [x] `std.fs.File` → `std.Io.File`
- [x] `std.fs.File.stdout()/stdin()/stderr()` → `std.Io.File.stdout()/stdin()/stderr()`
- [ ] `file.read()` now requires `Io` instance parameter
- [ ] `file.write()` now requires `Io` instance parameter
- [ ] `File.reader()` / `File.writer()` need `Io` + buffer parameters
- [ ] **Impact**: tools.zig file operations need significant rework

### 2. **Filesystem (`std.fs` removal)**
- [ ] `std.fs.cwd()` removed - no direct replacement
- [ ] `std.fs.openFileAbsolute()` / `openDirAbsolute()` may work
- [ ] **Impact**: tools.zig read_file and list_dir tools broken
- [ ] **Solution**: Use raw C `open()`/`opendir()` or absolute path APIs

### 3. **Process Spawning (`std.process.Child` rewritten)**
- [ ] `std.process.Child.init(argv, alloc)` → `process.spawn(io, options)`
- [ ] New `SpawnOptions` struct with different fields
- [ ] `stdin_behavior` → `stdin: StdIo` enum
- [ ] Requires `Io` instance for spawning
- [ ] **Impact**: client.zig McpClient.init() needs full rewrite

### 4. **Allocator Changes**
- [x] `GeneralPurposeAllocator` → `DebugAllocator`
- [x] `ArenaAllocator` still works but verify

### 5. **ArrayList Initialization**
- [x] `ArrayList(T).empty` → `.{ .items = &.{}, .capacity = 0 }`

### 6. **Argument Parsing**
- [x] `std.process.argsAlloc()` removed
- [x] Solution: Use `std.c._NSGetArgc()` / `std.c._NSGetArgv()` on Darwin
- [ ] **TODO**: Linux/Windows equivalents

### 7. **std.io Removal**
- [x] `std.io.getStdOut().writer()` → raw C `write()` with `STDOUT_FILENO`
- [x] `std.io.getStdErr().writer()` → raw C `write()` with `STDERR_FILENO`

### 8. **std.meta.fields**
- [ ] Verify still works or find replacement for `inline for (std.meta.fields(LogLevel))`

## Files Status

| File | Status | Notes |
|------|--------|-------|
| `main.zig` | ✅ Working | Simple arena init, no 0.15-specific APIs |
| `mcp.zig` | ⚠️ Partial | Raw I/O working, but uses tools.zig |
| `json.zig` | ✅ Working | Raw C read added for stdin |
| `tools.zig` | ❌ Broken | Needs fs.cwd() replacement |
| `client.zig` | ❌ Broken | Needs process spawn API rewrite |
| `client_example.zig` | ✅ Working | Uses raw C I/O |
| `registry.zig` | ⚠️ Unknown | Needs testing |

## Recommended Migration Strategy

### Option A: Minimal Changes (Raw C Fallback)
Use raw C syscalls for file and process operations where Zig APIs changed:
```zig
extern "c" fn open(path: [*]const u8, flags: c_int, ...) c_int;
extern "c" fn opendir(path: [*]const u8) ?*anyopaque;
extern "c" fn fork() c_int;
extern "c" fn execvp(file: [*]const u8, argv: [*]const ?[*]const u8) c_int;
```

### Option B: Embrace New Io API
Use the new `std.Io` system properly:
```zig
var io: std.Io = .{ .userdata = null, .vtable = &my_vtable };
var file = std.Io.File.open(&io, path, .{});
```

### Option C: Hybrid
Keep core protocol (mcp.zig) simple with raw C I/O, but use new APIs where they work well.

## Build Test

Current state:
```
❌ mcp-zig - tools.zig uses std.fs.cwd()
❌ mcp-client - client.zig uses old Child.init()
```

## Related

- This blocks using mcp-zig with projects that have migrated to 0.16 (e.g., claude-talk)
- The 0.16 Io system is more complex but more powerful (supports async I/O)

## References

- [Zig 0.16.0 Release Notes](https://ziglang.org/download/0.16.0/release-notes.html)
- `std.Io` documentation in 0.16 stdlib


Closes #7